### PR TITLE
Bulk add songs from cache/csv file

### DIFF
--- a/raven/commands.py
+++ b/raven/commands.py
@@ -40,7 +40,7 @@ def add_tracks(location, filename, source='cache'):
     r = Raven()
 
     if source == 'cache':
-        track_ids = [line.rstrip('\n') for line in open('.cache-tracks.txt', 'r')]
+        track_ids = [line.rstrip('\n') for line in open('.cache-{0}-tracks.txt'.format(os.environ['USERNAME']), 'r')]
 
     else:
         track_ids = r.search_song_ids(filepath=filename)

--- a/raven/commands.py
+++ b/raven/commands.py
@@ -36,14 +36,18 @@ def follow(filename):
             requests.put(url=r.spotify.prefix+follow_endpoint, headers=r.headers, params=params)
 
 
-def add_tracks(location, filename, source='cache'):
+def add_tracks(location, filename, source='library'):
     r = Raven()
 
     if source == 'cache':
         track_ids = [line.rstrip('\n') for line in open('.cache-{0}-tracks.txt'.format(os.environ['USERNAME']), 'r')]
 
     else:
-        track_ids = r.search_song_ids(filepath=filename)
+        if os.path.isfile(filename):
+            track_ids = r.search_song_ids(filepath=filename)
+        else:
+            print("Invalid file path entered. Try again.")
+            exit()
 
     username = os.environ['USERNAME']
     size = len(track_ids)

--- a/raven/constants.py
+++ b/raven/constants.py
@@ -4,4 +4,4 @@ scope = 'playlist-modify-public user-follow-modify user-library-modify playlist-
 follow_endpoint = 'me/following'
 playlist_add_endpoint = 'users/{user_id}/playlists/{playlist_id}/tracks'
 TRACK_URI_FORMAT = 'spotify:track:'
-DESCRIPTION="This playlist was created automagically by Raven https://github.com/bhavika/raven"
+DESCRIPTION = "This playlist was created automagically by Raven https://github.com/bhavika/raven"

--- a/raven/constants.py
+++ b/raven/constants.py
@@ -4,3 +4,4 @@ scope = 'playlist-modify-public user-follow-modify user-library-modify playlist-
 follow_endpoint = 'me/following'
 playlist_add_endpoint = 'users/{user_id}/playlists/{playlist_id}/tracks'
 TRACK_URI_FORMAT = 'spotify:track:'
+DESCRIPTION="This playlist was created automagically by Raven https://github.com/bhavika/raven"

--- a/raven/raven.py
+++ b/raven/raven.py
@@ -15,6 +15,8 @@ from raven.constants import scope
 
 load_dotenv(find_dotenv())
 
+logging.getLogger("requests").setLevel(logging.WARNING)
+
 
 class Raven(object):
 
@@ -118,7 +120,7 @@ class Raven(object):
                 r.refresh_token()
                 logging.debug(e.__str__())
 
-        with open('.cache-%s-tracks.txt'.format(os.environ['USERNAME']), 'w') as track_cache:
+        with open('.cache-{0}-tracks.txt'.format(os.environ['USERNAME']), 'w') as track_cache:
             for track in track_ids:
                 track_cache.write(track + '\n')
 


### PR DESCRIPTION
Log:

- `add-tracks` now takes a `source` arg that can be either `cache` or anything else (`file`, `library`, etc) and a filename (of style format.csv). 

- searching for song ids now saves all track_ids to a text file named as `.cache-[USERNAME]-tracks.txt` with the username to identify which cache is being used. This cache file can be deleted by the user after all tracks have been processed. 

